### PR TITLE
Fix to unescaped characters in mkdir && cp command

### DIFF
--- a/tasks/debian_package.js
+++ b/tasks/debian_package.js
@@ -1,4 +1,4 @@
-///*
+/*
  * grunt-debian-package
  * https://github.com/jamesdbloom/grunt-debian-package
  *


### PR DESCRIPTION
Added double quotes around the commands, $(VAR) will still behave the same.

I was running into issues where files had ( and) characters, it was crashing make.
