### PR TITLE
allow deactivation of dpkg-checkbuilddeps during debuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,12 @@ Default value: `process.env.BUILD_NUMBER || process.env.DRONE_BUILD_NUMBER || pr
 
 The second part of the version number.  This version number is intended to respresent a specific build of the package, for example this package might represetn the Jenkins or drone.io or TravisCI build number.  The default value is taken from an environment variable called `BUILD_NUMBER` or `DRONE_BUILD_NUMBER` or `TRAVIS_BUILD_NUMBER` which is compatible with Jenkins, drone.io and TravisCI respectively.
 
+### options.disable_debuild_deps_check
+Type: `Boolean`
+Default value: `false`
+
+Some distributions like Arch Linux will fail the dpkg dependency checks causing `debuild` to fail. Use with caution.
+
 #### options.target_architecture
 Type: `String` (possible values are `amd64`, `i386`, `all`, `any`)
 Default value: `all`

--- a/tasks/debian_package.js
+++ b/tasks/debian_package.js
@@ -58,7 +58,8 @@ module.exports = function (grunt) {
                     working_directory: 'tmp/',
                     packaging_directory_name: 'packaging',
                     target_architecture: "all",
-                    category: "misc"
+                    category: "misc",
+                    disable_debuild_deps_check: false
                 }),
                 spawn = require('child_process').spawn,
                 dateFormat = require('dateformat'),
@@ -129,7 +130,8 @@ module.exports = function (grunt) {
             grunt.verbose.writeln('Running \'debuild --no-tgz-check -sa -us -uc --lintian-opts --suppress-tags tar-errors-from-data,tar-errors-from-control,dir-or-file-in-var-www\'');
             if (!options.simulate) {
                 if (grunt.file.exists('/usr/bin/debuild')) {
-                    var debuild = spawn('debuild', ['--no-tgz-check', '-sa', '-us', '-uc', '--lintian-opts', '--suppress-tags', 'tar-errors-from-data,tar-errors-from-control,dir-or-file-in-var-www'], {
+                    var checkDeps = options.disable_debuild_deps_check ? "-d" : "-D";
+                    var debuild = spawn('debuild', ['--no-tgz-check', '-sa', checkDeps, '-us', '-uc', '--lintian-opts', '--suppress-tags', 'tar-errors-from-data,tar-errors-from-control,dir-or-file-in-var-www'], {
                         cwd: temp_directory,
                         stdio: [ 'ignore', (grunt.option('verbose') ? process.stdout : 'ignore'), process.stderr ]
                     });


### PR DESCRIPTION
on some systems dpkg does not find installed dependencies. this causes debuild to fail, even though the package would build fine with the -d flag.

this pr adds a new options called `disable_debuild_deps_check` and sets the -d flag when debuild is executed if the option is set to true. the default is false and preserves the current/standard behaviour.